### PR TITLE
适配64位系统类型

### DIFF
--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -120,7 +120,7 @@ int Tokenizer::isReservedWord(char *word) {
             "user", "view", "rule", "default", "check", "between", "trigger", "primary", "key", "foreign"
     };
     int isReservedWord = 0;
-    int size = sizeof(reservedWords)/sizeof(1);
+    int size = sizeof(reservedWords)/sizeof(reservedWords[0]);
     for (int rWordIndex = 0; rWordIndex <= size - 1; rWordIndex++) {
         if (stricmp(word, reservedWords[rWordIndex]) == 0) {
             isReservedWord = 1;


### PR DESCRIPTION
更正命令数组的计算方法，使用二维数组常用的计算元素个数的方式